### PR TITLE
Add Enter key to open selected items in browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4", features = ["derive"] }
 async-trait = "0.1"
 futures = "0.3"
 urlencoding = "2"
+open = "5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,23 +1,23 @@
 use crate::config::{Config, WidgetConfig};
-use crate::creature::Creature;
 use crate::creature::persistence::{default_creature_path, load_or_create_creature, save_creature};
+use crate::creature::Creature;
 use crate::event::{Event, EventHandler};
 use crate::feeds::{FeedData, FeedMessage};
 use crate::ui::creature_menu::CreatureMenu;
 use crate::ui::widgets::{
-    FeedWidget, creature::CreatureWidget, github::GithubWidget, hackernews::HackernewsWidget,
-    rss::RssWidget, sports::SportsWidget, stocks::StocksWidget, youtube::YoutubeWidget,
+    creature::CreatureWidget, github::GithubWidget, hackernews::HackernewsWidget, rss::RssWidget,
+    sports::SportsWidget, stocks::StocksWidget, youtube::YoutubeWidget, FeedWidget,
 };
 use anyhow::Result;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture, KeyCode, KeyModifiers},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
-    Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
+    Frame, Terminal,
 };
 use std::io::{self, Stdout};
 use std::path::PathBuf;
@@ -198,6 +198,7 @@ impl App {
                     KeyCode::Up | KeyCode::Char('k') => self.scroll_up(),
                     KeyCode::Left | KeyCode::Char('h') => self.switch_tab_prev(),
                     KeyCode::Right | KeyCode::Char('l') => self.switch_tab_next(),
+                    KeyCode::Enter => self.open_selected_url(),
                     _ => {}
                 }
             }
@@ -322,6 +323,15 @@ impl App {
                 {
                     github_widget.prev_tab();
                 }
+            }
+        }
+    }
+
+    /// Open the selected item's URL in the default browser
+    fn open_selected_url(&self) {
+        if !self.widgets.is_empty() {
+            if let Some(url) = self.widgets[self.selected_widget].get_selected_url() {
+                let _ = open::that(&url);
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,7 +239,7 @@ impl Default for Config {
                 WidgetConfig::Rss(RssConfig {
                     title: "Tech News".to_string(),
                     feeds: vec![
-                        "https://feeds.arstechnica.com/arstechnica/technology-lab".to_string(),
+                        "https://feeds.arstechnica.com/arstechnica/technology-lab".to_string()
                     ],
                     max_items: 10,
                     position: Position { row: 1, col: 1 },

--- a/src/feeds/mod.rs
+++ b/src/feeds/mod.rs
@@ -51,6 +51,7 @@ pub struct RssItem {
     pub link: Option<String>,
     pub published: Option<String>,
     pub source: String,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/feeds/rss.rs
+++ b/src/feeds/rss.rs
@@ -47,6 +47,7 @@ impl RssFetcher {
                     .published
                     .map(|d| d.format("%Y-%m-%d %H:%M").to_string()),
                 source: source_name.clone(),
+                description: entry.summary.map(|s| s.content),
             })
             .collect();
 

--- a/src/feeds/youtube.rs
+++ b/src/feeds/youtube.rs
@@ -27,9 +27,18 @@ struct SearchItem {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum VideoId {
-    Video { #[serde(rename = "videoId")] video_id: String },
-    Channel { #[serde(rename = "channelId")] channel_id: String },
-    Playlist { #[serde(rename = "playlistId")] playlist_id: String },
+    Video {
+        #[serde(rename = "videoId")]
+        video_id: String,
+    },
+    Channel {
+        #[serde(rename = "channelId")]
+        channel_id: String,
+    },
+    Playlist {
+        #[serde(rename = "playlistId")]
+        playlist_id: String,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -205,11 +214,7 @@ impl YoutubeFetcher {
                 let thumbnail_url = video
                     .snippet
                     .thumbnails
-                    .and_then(|t| {
-                        t.medium
-                            .or(t.high)
-                            .or(t.default)
-                    })
+                    .and_then(|t| t.medium.or(t.high).or(t.default))
                     .map(|info| info.url);
 
                 let view_count = video
@@ -320,11 +325,7 @@ fn format_duration(iso_duration: &str) -> String {
 
 fn format_published_date(iso_date: &str) -> String {
     // Simple formatting - just extract date portion
-    iso_date
-        .split('T')
-        .next()
-        .unwrap_or(iso_date)
-        .to_string()
+    iso_date.split('T').next().unwrap_or(iso_date).to_string()
 }
 fn truncate_description(desc: &str) -> String {
     let char_count = desc.chars().count();
@@ -334,5 +335,4 @@ fn truncate_description(desc: &str) -> String {
     } else {
         desc.to_string()
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,10 +113,7 @@ fn init_config(force: bool) -> Result<()> {
     io::stdout().flush()?;
     let mut refresh_input = String::new();
     io::stdin().read_line(&mut refresh_input)?;
-    let refresh_interval = refresh_input
-        .trim()
-        .parse::<u64>()
-        .unwrap_or(60);
+    let refresh_interval = refresh_input.trim().parse::<u64>().unwrap_or(60);
 
     // Prompt for theme
     print!("Theme (dark/light) [dark]: ");

--- a/src/ui/creature_menu.rs
+++ b/src/ui/creature_menu.rs
@@ -1,13 +1,13 @@
 use crate::creature::{
-    Creature, CreatureColor, CreatureSpecies, art::get_creature_art, get_all_outfits,
-    get_skill_tree,
+    art::get_creature_art, get_all_outfits, get_skill_tree, Creature, CreatureColor,
+    CreatureSpecies,
 };
 use ratatui::{
-    Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs},
+    Frame,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/ui/widgets/creature.rs
+++ b/src/ui/widgets/creature.rs
@@ -1,14 +1,14 @@
 use crate::config::CreatureConfig;
-use crate::creature::Creature;
 use crate::creature::art::{get_creature_art, get_greeting, get_idle_message};
+use crate::creature::Creature;
 use crate::feeds::{FeedData, FeedFetcher};
 use crate::ui::widgets::FeedWidget;
 use ratatui::{
-    Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Gauge, Paragraph},
+    Frame,
 };
 use std::time::Instant;
 

--- a/src/ui/widgets/github.rs
+++ b/src/ui/widgets/github.rs
@@ -5,11 +5,11 @@ use crate::feeds::{
 };
 use crate::ui::widgets::FeedWidget;
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Tabs},
+    Frame,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -416,5 +416,20 @@ impl FeedWidget for GithubWidget {
 
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         Some(self)
+    }
+
+    fn get_selected_url(&self) -> Option<String> {
+        let idx = self.scroll_state.selected()?;
+        match self.current_tab {
+            DashboardTab::Notifications => {
+                self.dashboard.notifications.get(idx).map(|n| n.url.clone())
+            }
+            DashboardTab::PullRequests => self
+                .dashboard
+                .pull_requests
+                .get(idx)
+                .map(|pr| format!("https://github.com/{}/pull/{}", pr.repository, pr.number)),
+            DashboardTab::Commits => self.dashboard.commits.get(idx).map(|c| c.url.clone()),
+        }
     }
 }

--- a/src/ui/widgets/hackernews.rs
+++ b/src/ui/widgets/hackernews.rs
@@ -3,11 +3,11 @@ use crate::feeds::hackernews::HnFetcher;
 use crate::feeds::{FeedData, FeedFetcher, HnStory};
 use crate::ui::widgets::FeedWidget;
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
+    Frame,
 };
 
 pub struct HackernewsWidget {
@@ -157,5 +157,18 @@ impl FeedWidget for HackernewsWidget {
 
     fn set_selected(&mut self, selected: bool) {
         self.selected = selected;
+    }
+
+    fn get_selected_url(&self) -> Option<String> {
+        self.scroll_state
+            .selected()
+            .and_then(|idx| self.stories.get(idx))
+            .and_then(|story| {
+                // Prefer the story URL, fall back to HN comments page
+                story
+                    .url
+                    .clone()
+                    .or_else(|| Some(format!("https://news.ycombinator.com/item?id={}", story.id)))
+            })
     }
 }

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -7,7 +7,7 @@ pub mod stocks;
 pub mod youtube;
 
 use crate::feeds::{FeedData, FeedFetcher};
-use ratatui::{Frame, layout::Rect};
+use ratatui::{layout::Rect, Frame};
 use std::any::Any;
 
 pub trait FeedWidget: Send + Sync {
@@ -20,6 +20,11 @@ pub trait FeedWidget: Send + Sync {
     fn scroll_up(&mut self);
     fn scroll_down(&mut self);
     fn set_selected(&mut self, selected: bool);
+
+    /// Get the URL of the currently selected item (if any)
+    fn get_selected_url(&self) -> Option<String> {
+        None
+    }
 
     /// For downcasting to concrete types
     fn as_any(&self) -> Option<&dyn Any> {

--- a/src/ui/widgets/rss.rs
+++ b/src/ui/widgets/rss.rs
@@ -3,11 +3,11 @@ use crate::feeds::rss::RssFetcher;
 use crate::feeds::{FeedData, FeedFetcher, RssItem};
 use crate::ui::widgets::FeedWidget;
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
+    Frame,
 };
 
 pub struct RssWidget {
@@ -156,5 +156,12 @@ impl FeedWidget for RssWidget {
 
     fn set_selected(&mut self, selected: bool) {
         self.selected = selected;
+    }
+
+    fn get_selected_url(&self) -> Option<String> {
+        self.scroll_state
+            .selected()
+            .and_then(|idx| self.items.get(idx))
+            .and_then(|item| item.link.clone())
     }
 }

--- a/src/ui/widgets/sports.rs
+++ b/src/ui/widgets/sports.rs
@@ -3,11 +3,11 @@ use crate::feeds::sports::SportsFetcher;
 use crate::feeds::{FeedData, FeedFetcher, SportsEvent};
 use crate::ui::widgets::FeedWidget;
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
+    Frame,
 };
 
 pub struct SportsWidget {

--- a/src/ui/widgets/stocks.rs
+++ b/src/ui/widgets/stocks.rs
@@ -3,11 +3,11 @@ use crate::feeds::stocks::StocksFetcher;
 use crate::feeds::{FeedData, FeedFetcher, StockQuote};
 use crate::ui::widgets::FeedWidget;
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
+    Frame,
 };
 
 pub struct StocksWidget {

--- a/src/ui/widgets/youtube.rs
+++ b/src/ui/widgets/youtube.rs
@@ -64,8 +64,8 @@ impl FeedWidget for YoutubeWidget {
             .border_style(border_style);
 
         if self.loading && self.videos.is_empty() {
-            let loading_text = List::new(vec![ListItem::new("Loading YouTube videos...")])
-                .block(block);
+            let loading_text =
+                List::new(vec![ListItem::new("Loading YouTube videos...")]).block(block);
             frame.render_widget(loading_text, area);
             return;
         }
@@ -90,10 +90,7 @@ impl FeedWidget for YoutubeWidget {
             .map(|(i, video)| {
                 // Title line with numbering
                 let title_line = Line::from(vec![
-                    Span::styled(
-                        format!("{}. ", i + 1),
-                        Style::default().fg(Color::DarkGray),
-                    ),
+                    Span::styled(format!("{}. ", i + 1), Style::default().fg(Color::DarkGray)),
                     Span::styled(&video.title, Style::default().fg(Color::White)),
                 ]);
 
@@ -182,5 +179,12 @@ impl FeedWidget for YoutubeWidget {
 
     fn set_selected(&mut self, selected: bool) {
         self.selected = selected;
+    }
+
+    fn get_selected_url(&self) -> Option<String> {
+        self.scroll_state
+            .selected()
+            .and_then(|idx| self.videos.get(idx))
+            .map(|video| format!("https://www.youtube.com/watch?v={}", video.id))
     }
 }


### PR DESCRIPTION
## Summary
- Added ability to press Enter on any feed item to open it in the default browser
- Implemented `get_selected_url` method for all feed widgets (Hacker News, RSS, YouTube, GitHub)
- Added `open` crate for cross-platform URL opening
- Added description field to RssItem for future content display

## Behavior
- **Hacker News**: Opens article URL, falls back to comments page for text posts
- **RSS**: Opens the article link
- **YouTube**: Opens the video watch page
- **GitHub**: Opens notification URL, PR page, or commit page based on current tab

## Test plan
- [ ] Select a Hacker News story and press Enter - should open in browser
- [ ] Select an RSS article and press Enter - should open in browser  
- [ ] Select a YouTube video and press Enter - should open YouTube
- [ ] Select a GitHub notification/PR/commit and press Enter - should open GitHub

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)