### PR TITLE
Fix Linux aarch64 cross-compilation by switching to rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 ratatui = "0.29"
 crossterm = "0.28"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"


### PR DESCRIPTION
The aarch64 build was failing with "openssl/opensslv.h: No such file" because cross-compilation to aarch64 requires OpenSSL dev headers for that architecture, which aren't available in the manylinux container.

Solution: Switch reqwest from native-tls (OpenSSL) to rustls-tls, a pure-Rust TLS implementation that compiles cleanly for all targets without system dependencies.

Changes:
- Enable rustls-tls feature for reqwest
- Disable default features (which include native-tls)
- Keep json feature enabled

Benefits:
✅ No OpenSSL dependency = easier cross-compilation ✅ Works on all platforms (Linux x86_64, aarch64, Windows, macOS) ✅ Pure Rust = more portable and reproducible builds ✅ Smaller binary size

This fixes the Linux aarch64 build failure while maintaining full functionality across all platforms.