### PR TITLE
Fix aarch64 cross-compilation using Zig toolchain

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -26,12 +26,9 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --find-interpreter --zig
           sccache: 'true'
           manylinux: auto
-          before-script-linux: |
-            # Install dependencies for manylinux
-            yum install -y openssl-devel || true
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The ring/rustls crypto library was failing to cross-compile to aarch64 due to ARM assembler issues: "ARM assembler must define __ARM_ARCH"

Solution: Use Zig for cross-compilation via maturin's --zig flag.

Why Zig fixes this:
✅ Zig provides excellent cross-compilation support out of the box ✅ Handles all toolchain complexity automatically
✅ Works seamlessly with ring/rustls and other native dependencies ✅ No need for platform-specific build scripts or dependency installs

Changes:
- Add --zig flag to Linux build args
- Remove before-script-linux (no longer needed)
- Keep aarch64 target enabled

Zig is built into PyO3/maturin-action and handles cross-compilation better than traditional gcc/clang toolchains.