### PR TITLE
Fix Python 3.14 compatibility by using explicit version matrix

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -15,25 +15,26 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: ${{ matrix.python-version }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --zig
+          args: --release --out dist --zig
           sccache: 'true'
           manylinux: auto
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.target }}
+          name: wheels-linux-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist
 
   windows:


### PR DESCRIPTION
The --find-interpreter flag was finding Python 3.14, which PyO3 0.22.6 doesn't support yet (max version is 3.13), causing build failures: "the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)"

Solution: Use explicit Python version matrix (3.8-3.13) for Linux, matching the approach used for Windows and macOS.

Changes:
- Add python-version matrix to Linux job
- Remove --find-interpreter flag (no longer needed)
- Keep --zig for cross-compilation
- Update artifact names to include Python version

This ensures we only build for Python versions that PyO3 supports, avoiding the 3.14 compatibility issue.

Build matrix now:
- Linux: 2 architectures × 6 Python versions = 12 wheels
- Windows: 1 architecture × 6 Python versions = 6 wheels
- macOS: 2 architectures × 6 Python versions = 12 wheels
- Total: 30 wheels + 1 sdist