### PR TITLE
Fix Bird CLI widget: navigation, text wrapping, error handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -232,6 +232,11 @@ impl App {
 
                 // Normal event handling
                 match key.code {
+                    KeyCode::Esc => {
+                        if self.is_twitter_selected() {
+                            self.twitter_escape();
+                        }
+                    }
                     KeyCode::Char('q') => self.should_quit = true,
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         self.should_quit = true
@@ -652,12 +657,23 @@ impl App {
                 {
                     match key.code {
                         KeyCode::Esc => {
-                            tw.close_modal();
-                            tw.close_detail_view();
+                            if tw.has_detail_view() {
+                                tw.close_detail_view();
+                            } else {
+                                tw.close_modal();
+                            }
                         }
-                        KeyCode::Char(c) => tw.add_char(c),
+                        KeyCode::Down | KeyCode::Char('j') if tw.has_detail_view() => {
+                            tw.scroll_detail_down();
+                        }
+                        KeyCode::Up | KeyCode::Char('k') if tw.has_detail_view() => {
+                            tw.scroll_detail_up();
+                        }
+                        KeyCode::Char(c) if !tw.has_detail_view() => {
+                            tw.add_char(c);
+                        }
                         KeyCode::Backspace => tw.delete_char(),
-                        KeyCode::Enter => {
+                        KeyCode::Enter if !tw.has_detail_view() => {
                             // Extract data needed for spawning command
                             let widget_id = tw.id();
                             let mode = tw.get_mode();
@@ -689,6 +705,21 @@ impl App {
                 .is_some()
         } else {
             false
+        }
+    }
+
+    fn twitter_escape(&mut self) {
+        if let Some(widget) = self.widgets.get_mut(self.selected_widget) {
+            if let Some(tw) = widget
+                .as_any_mut()
+                .and_then(|w| w.downcast_mut::<TwitterWidget>())
+            {
+                if tw.has_detail_view() {
+                    tw.close_detail_view();
+                } else if tw.has_tweets() {
+                    tw.clear_tweets();
+                }
+            }
         }
     }
 
@@ -811,6 +842,11 @@ impl App {
                             Err(e) => TwitterData::Error(e.to_string()),
                         };
                         let _ = tx.send(TwitterMessage { widget_id, data });
+                    });
+                } else {
+                    let _ = tx.send(TwitterMessage {
+                        widget_id,
+                        data: TwitterData::Error("No tweet selected to reply to".to_string()),
                     });
                 }
             }

--- a/src/ui/widgets/twitter.rs
+++ b/src/ui/widgets/twitter.rs
@@ -44,6 +44,7 @@ pub use crate::twitter_message::Tweet;
 #[derive(Debug, Clone)]
 struct TweetDetail {
     content: String,
+    scroll_offset: u16,
 }
 
 impl TwitterWidget {
@@ -118,6 +119,33 @@ impl TwitterWidget {
         self.detail_view = None;
     }
 
+    pub fn clear_tweets(&mut self) {
+        self.tweets.clear();
+        self.selected_index = 0;
+        self.list_state.select(Some(0));
+        self.detail_view = None;
+    }
+
+    pub fn has_tweets(&self) -> bool {
+        !self.tweets.is_empty()
+    }
+
+    pub fn has_detail_view(&self) -> bool {
+        self.detail_view.is_some()
+    }
+
+    pub fn scroll_detail_down(&mut self) {
+        if let Some(detail) = &mut self.detail_view {
+            detail.scroll_offset = detail.scroll_offset.saturating_add(1);
+        }
+    }
+
+    pub fn scroll_detail_up(&mut self) {
+        if let Some(detail) = &mut self.detail_view {
+            detail.scroll_offset = detail.scroll_offset.saturating_sub(1);
+        }
+    }
+
     pub async fn execute_bird_command_static(args: &[&str]) -> anyhow::Result<String> {
         // Check for environment variables
         let ct0 = std::env::var("CT0").map_err(|_| {
@@ -150,15 +178,24 @@ impl TwitterWidget {
                 }
             })?;
 
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        // Filter out Node.js ExperimentalWarning lines from stderr
+        let filtered_stderr: String = stderr
+            .lines()
+            .filter(|line| !line.contains("ExperimentalWarning"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filtered_stderr = filtered_stderr.trim();
+
         if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+            Ok(stdout)
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let msg = if stderr.is_empty() {
-                stdout.to_string()
+            let msg = if filtered_stderr.is_empty() {
+                stdout
             } else {
-                stderr.to_string()
+                filtered_stderr.to_string()
             };
             Err(anyhow::anyhow!("Bird command failed: {}", msg.trim()))
         }
@@ -237,7 +274,10 @@ impl TwitterWidget {
                 }
             }
             TwitterData::TweetDetail(content) => {
-                self.detail_view = Some(TweetDetail { content });
+                self.detail_view = Some(TweetDetail {
+                    content,
+                    scroll_offset: 0,
+                });
             }
             TwitterData::Error(e) => {
                 self.set_status(format!("Error: {}", e));
@@ -311,6 +351,7 @@ impl FeedWidget for TwitterWidget {
             let paragraph = Paragraph::new(help_text).alignment(Alignment::Center);
             frame.render_widget(paragraph, inner);
         } else {
+            let max_text_width = inner.width.saturating_sub(2) as usize;
             let items: Vec<ListItem> = self
                 .tweets
                 .iter()
@@ -321,10 +362,16 @@ impl FeedWidget for TwitterWidget {
                     } else {
                         Style::default().fg(Color::White)
                     };
+                    let prefix = format!("@{}: ", tweet.author);
+                    let remaining = max_text_width.saturating_sub(prefix.len());
+                    let text = if tweet.text.len() > remaining {
+                        format!("{}...", &tweet.text[..remaining.saturating_sub(3)])
+                    } else {
+                        tweet.text.clone()
+                    };
                     ListItem::new(Line::from(vec![
-                        Span::styled(&tweet.author, style.add_modifier(Modifier::BOLD)),
-                        Span::raw(": "),
-                        Span::styled(&tweet.text, style),
+                        Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
+                        Span::styled(text, style),
                     ]))
                 })
                 .collect();
@@ -398,7 +445,7 @@ impl FeedWidget for TwitterWidget {
 
 impl TwitterWidget {
     fn render_compose_modal(&self, frame: &mut Frame, area: Rect) {
-        let modal_area = self.center_rect(60, 30, area);
+        let modal_area = self.centered_modal(area, 50, 10);
         frame.render_widget(Clear, modal_area);
 
         let block = Block::default()
@@ -409,9 +456,20 @@ impl TwitterWidget {
         let inner = block.inner(modal_area);
         frame.render_widget(block, modal_area);
 
+        let display_text = if self.compose_text.is_empty() {
+            "Type your tweet...".to_string()
+        } else {
+            self.compose_text.clone()
+        };
+
+        let text_style = if self.compose_text.is_empty() {
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
         let text = vec![
-            Line::from(""),
-            Line::from(self.compose_text.as_str()),
+            Line::from(Span::styled(display_text, text_style)),
             Line::from(""),
             Line::from(Span::styled(
                 "Enter to post | Esc to cancel",
@@ -424,7 +482,7 @@ impl TwitterWidget {
     }
 
     fn render_reply_modal(&self, frame: &mut Frame, area: Rect) {
-        let modal_area = self.center_rect(60, 30, area);
+        let modal_area = self.centered_modal(area, 50, 12);
         frame.render_widget(Clear, modal_area);
 
         let block = Block::default()
@@ -435,22 +493,58 @@ impl TwitterWidget {
         let inner = block.inner(modal_area);
         frame.render_widget(block, modal_area);
 
-        let text = vec![
-            Line::from(""),
-            Line::from(self.compose_text.as_str()),
-            Line::from(""),
-            Line::from(Span::styled(
-                "Enter to post | Esc to cancel",
-                Style::default().fg(Color::DarkGray),
-            )),
-        ];
+        let mut lines = Vec::new();
 
-        let paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
+        // Show which tweet is being replied to
+        if let Some(tweet) = self.tweets.get(self.selected_index) {
+            lines.push(Line::from(vec![
+                Span::styled("To @", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    &tweet.author,
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(": ", Style::default().fg(Color::DarkGray)),
+            ]));
+            let preview_width = inner.width.saturating_sub(2) as usize;
+            let preview = if tweet.text.len() > preview_width {
+                format!("{}...", &tweet.text[..preview_width.saturating_sub(3)])
+            } else {
+                tweet.text.clone()
+            };
+            lines.push(Line::from(Span::styled(
+                preview,
+                Style::default().fg(Color::DarkGray),
+            )));
+            lines.push(Line::from(""));
+        }
+
+        let display_text = if self.compose_text.is_empty() {
+            "Type your reply...".to_string()
+        } else {
+            self.compose_text.clone()
+        };
+
+        let text_style = if self.compose_text.is_empty() {
+            Style::default().fg(Color::DarkGray)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        lines.push(Line::from(Span::styled(display_text, text_style)));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Enter to post | Esc to cancel",
+            Style::default().fg(Color::DarkGray),
+        )));
+
+        let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
         frame.render_widget(paragraph, inner);
     }
 
     fn render_search_modal(&self, frame: &mut Frame, area: Rect) {
-        let modal_area = self.center_rect(60, 20, area);
+        let modal_area = self.centered_modal(area, 50, 7);
         frame.render_widget(Clear, modal_area);
 
         let block = Block::default()
@@ -462,7 +556,6 @@ impl TwitterWidget {
         frame.render_widget(block, modal_area);
 
         let text = vec![
-            Line::from(""),
             Line::from(format!("Query: {}", self.search_query)),
             Line::from(""),
             Line::from(Span::styled(
@@ -471,7 +564,7 @@ impl TwitterWidget {
             )),
         ];
 
-        let paragraph = Paragraph::new(text);
+        let paragraph = Paragraph::new(text).wrap(Wrap { trim: false });
         frame.render_widget(paragraph, inner);
     }
 
@@ -482,14 +575,14 @@ impl TwitterWidget {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Cyan))
-            .title("Tweet Detail");
+            .title("Tweet Detail (j/k scroll, Esc close)");
 
         let inner = block.inner(modal_area);
         frame.render_widget(block, modal_area);
 
         let paragraph = Paragraph::new(detail.content.as_str())
             .wrap(Wrap { trim: false })
-            .block(Block::default());
+            .scroll((detail.scroll_offset, 0));
         frame.render_widget(paragraph, inner);
     }
 
@@ -505,9 +598,20 @@ impl TwitterWidget {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Yellow));
 
-        let paragraph = Paragraph::new(message).block(block);
+        let paragraph = Paragraph::new(message)
+            .block(block)
+            .wrap(Wrap { trim: true });
         frame.render_widget(Clear, status_area);
         frame.render_widget(paragraph, status_area);
+    }
+
+    /// Create a centered modal rect with absolute minimum sizes
+    fn centered_modal(&self, area: Rect, min_width: u16, min_height: u16) -> Rect {
+        let width = area.width.saturating_sub(4).max(min_width).min(area.width);
+        let height = min_height.min(area.height);
+        let x = area.x + area.width.saturating_sub(width) / 2;
+        let y = area.y + area.height.saturating_sub(height) / 2;
+        Rect::new(x, y, width, height)
     }
 
     fn center_rect(&self, percent_x: u16, percent_y: u16, r: Rect) -> Rect {


### PR DESCRIPTION
## Summary

Fixes all issues reported in #56:

- **Esc key now works** to exit search results and mentions views
- **Detail view scrolling** with j/k keys
- **Node ExperimentalWarning** no longer treated as command failure
- **Text wrapping** for tweets, modals, and status messages
- **Reply modal** shows which tweet is being replied to
- **Small terminal support** with absolute minimum modal sizes

## Root Causes & Fixes

### 1. Unable to exit search/mentions (Esc not working)

**Root cause:** After async results loaded, `close_modal()` set mode to Normal and `is_modal_open()` returned false. All key events went to the normal handler, which had no Esc case.

**Fix:** Added Esc handler in normal mode that clears tweets when Twitter widget is selected. Esc in detail view closes detail first; second press clears tweets.

### 2. Detail view not scrollable

**Root cause:** `is_modal_open()` returned true for detail view, routing events to the modal handler which only handled Esc/Char/Backspace/Enter. Navigation keys were silently swallowed.

**Fix:** Added scroll offset to `TweetDetail` and j/k/up/down handlers in the modal event handler when detail view is active.

### 3. Compose error (Node ExperimentalWarning)

**Root cause:** Bird CLI stderr contained Node.js `ExperimentalWarning` lines that were shown as the error message even when they aren't real errors.

**Fix:** Filter out lines containing `ExperimentalWarning` from stderr before reporting errors.

### 4. Text clipped on right side

**Root cause:** Tweet list used `Line` (single-line, no wrapping). Long tweets were clipped.

**Fix:** Truncate tweet text to available width with `...` ellipsis. Added `Wrap` to status messages and search modal.

### 5. Compose input invisible in small windows

**Root cause:** Modals used percentage-based sizing that became too small in small terminals.

**Fix:** New `centered_modal()` helper with absolute minimum sizes. Placeholder text hints when input is empty.

### 6. Reply not working / no feedback

**Root cause:** When `tweet_url` was None, the reply case silently did nothing.

**Fix:** Send `TwitterData::Error("No tweet selected to reply to")` when URL is missing. Reply modal now shows the tweet being replied to (author + text preview).

## Files Changed

- `src/app.rs` — Esc handler in normal mode, detail view navigation, reply error feedback
- `src/ui/widgets/twitter.rs` — Scroll support, modal layout, text truncation, Node warning filter, reply context display

## Test Plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 6/6 pass
- [x] `cargo build` — success
- [ ] Manual: search tweets, Esc to clear results
- [ ] Manual: load mentions, Esc to exit
- [ ] Manual: open detail view, scroll with j/k, Esc to close
- [ ] Manual: compose tweet in small terminal
- [ ] Manual: reply to tweet, verify context shown

Resolves #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)