### PR TITLE
Add nix flake for building feedtui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "A configurable terminal dashboard for stocks, news, sports, and social feeds with a virtual pet companion";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          feedtui = pkgs.rustPlatform.buildRustPackage {
+            pname = "feedtui";
+            version = "0.1.2";
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            meta = with pkgs.lib; {
+              description = "A configurable terminal dashboard for stocks, news, sports, and social feeds";
+              homepage = "https://github.com/muk2/feedtui";
+              license = licenses.mit;
+              maintainers = [ ];
+            };
+          };
+
+          default = self.packages.${system}.feedtui;
+        });
+    };
+}


### PR DESCRIPTION
## Summary
- Adds a nix flake to package and run feedtui from remote
- Adds `flake.nix` and `flake.lock` for nix build support  
- Adds `result` to `.gitignore` (nix build output directory)

Supersedes #33 — cherry-picked the nix flake commit onto current `main` to resolve `Cargo.lock` merge conflicts.

Credit: @borja-rojo-ilvento (original PR #33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)